### PR TITLE
feat: count ADR from when it is available

### DIFF
--- a/apps/web/src/entities/match/types.ts
+++ b/apps/web/src/entities/match/types.ts
@@ -31,6 +31,7 @@ export interface Match {
 	"Triple Kills": string;
 	"Updated At": string;
 	Winner: string;
+	ADR: string;
 }
 
 export interface GameStats {
@@ -41,5 +42,6 @@ export interface GameStats {
 	"Headshots %": string;
 	"K/D Ratio": string;
 	"K/R Ratio": string;
+	ADR: string;
 	Rounds: string;
 }

--- a/apps/web/src/entities/profile/lib/stats.tsx
+++ b/apps/web/src/entities/profile/lib/stats.tsx
@@ -44,62 +44,46 @@ export const calculateAverageStats = (matches: GameStats[]) => {
 			weight,
 		};
 
-	const kills = matches
-		.map((match) => +match["Kills"])
-		.reduce((prev, kills) => prev + kills, 0);
+	const matchStats = matches.map((match) => {
+		return {
+			kills: +match["Kills"],
+			deaths: +match["Deaths"],
+			rounds: +match["Rounds"],
+			kpr: +match["K/R Ratio"],
+			adr: +match["ADR"] || +match["K/R Ratio"] * DMG_PER_KILL, // adr was added late june, so estimate it until it was added
+			headshots: +match["Headshots"],
+			assists: +match["Assists"],
+		};
+	});
 
-	const deaths = matches
-		.map((match) => +match["Deaths"])
-		.reduce((prev, deaths) => prev + deaths, 0);
-
+	const kills = matchStats.reduce((prev, stat) => prev + stat.kills, 0);
+	const deaths = matchStats.reduce((prev, stat) => prev + stat.deaths, 0);
 	const kd = kills / deaths || 0;
 
 	const dpr =
-		matches
-			.map((match) => +match["Deaths"] / +match["Rounds"])
-			.reduce((prev, dpr) => prev + dpr, 0) / weight;
-
-	const kpr =
-		matches
-			.map((match) => +match["K/R Ratio"])
-			.reduce((prev, kpr) => prev + kpr, 0) / weight;
-
+		matchStats.reduce((prev, stat) => prev + stat.deaths / stat.rounds, 0) /
+		weight;
+	const kpr = matchStats.reduce((prev, stat) => prev + stat.kpr, 0) / weight;
 	const avgk = kills / weight;
+	const adr = matchStats.reduce((prev, stat) => prev + stat.adr, 0) / weight;
 
-	const adr =
-		matches
-			.map((match) => +match["K/R Ratio"] * DMG_PER_KILL)
-			.reduce((prev, adr) => prev + adr, 0) / weight;
-
-	const hs = matches
-		.map((match) => +match["Headshots"])
-		.reduce((prev, hs) => prev + hs, 0);
-
+	const hs = matchStats.reduce((prev, stat) => prev + stat.headshots, 0);
 	const hsp = (hs / kills) * 100;
-
 	const apr =
-		matches
-			.map((match) => +match["Assists"] / +match["Rounds"])
-			.reduce((prev, apr) => prev + apr, 0) / weight;
+		matchStats.reduce(
+			(prev, stat) => prev + stat.assists / stat.rounds,
+			0,
+		) / weight;
 
 	const kast =
-		matches
-			.map((match) => {
-				const kills = +match["Kills"];
-				const deaths = +match["Deaths"];
-				const assists = +match["Assists"];
-				const rounds = +match["Rounds"];
-				const survived = rounds - deaths;
-				const traded = TRADE_PERCENT * rounds;
-
-				const sum = (kills + assists + survived + traded) * 0.45;
-
-				return Math.min((sum / rounds) * 100, 100);
-			})
-			.reduce((prev, kast) => prev + kast, 0) / weight;
+		matchStats.reduce((prev, stat) => {
+			const survived = stat.rounds - stat.deaths;
+			const traded = TRADE_PERCENT * stat.rounds;
+			const sum = (stat.kills + stat.assists + survived + traded) * 0.45;
+			return prev + Math.min((sum / stat.rounds) * 100, 100);
+		}, 0) / weight;
 
 	const impact = Math.max(2.13 * kpr + 0.42 * apr - 0.41, 0);
-
 	const rating = Math.max(
 		0.0073 * kast +
 			0.3591 * kpr +

--- a/apps/web/src/shared/api.ts
+++ b/apps/web/src/shared/api.ts
@@ -411,6 +411,7 @@ export type GetMatchStatsDto = Dto<
 						Headshots: string;
 						Result: string;
 						"K/D Ratio": string;
+						ADR: string;
 					};
 				}[];
 			}[];


### PR DESCRIPTION
ADR doesn't seem to be introduced until late June in the faceit API, therefor it seems to be an estimate of ADR when counting the stats.

This PR uses the ADR if it's available and falls back on the estimate if it's not available, there for making "current form" and recent matches accurate, while lifetime and older games falls back to the estimate.

Closes #6 