### PR TITLE
fix: group matches by unique date for correct session display

### DIFF
--- a/apps/web/src/entities/match/lib/group.tsx
+++ b/apps/web/src/entities/match/lib/group.tsx
@@ -1,35 +1,19 @@
+import * as datefns from "date-fns";
+
 import {Match} from "../types";
 
 export const groupMatchesIntoSessions = (matches: Match[]) => {
-	const SESSION_INTERVAL_HOURS = 4;
-	const MATCH_DURATION = 0.65;
-
-	const sessions: Match[][] = [];
+	const sessions: Record<string, Match[]> = {};
 
 	matches.forEach((match) => {
-		const time = new Date(match["Created At"]).getTime();
+		const dateOnly = datefns.format(match["Created At"], "dd/MM/yy");
 
-		const empty = sessions.length === 0;
-
-		if (empty) {
-			sessions.push([match]);
-		} else {
-			const lastSession = sessions[sessions.length - 1];
-			const lastMatch = lastSession[lastSession.length - 1];
-
-			const lastMatchTime = new Date(lastMatch["Created At"]).getTime();
-
-			const timeDifference = (lastMatchTime - time) / (1000 * 60 * 60);
-
-			const timeThreshold = SESSION_INTERVAL_HOURS + MATCH_DURATION;
-
-			if (timeDifference <= timeThreshold) {
-				lastSession.push(match);
-			} else {
-				sessions.push([match]);
-			}
+		if (!sessions[dateOnly]) {
+			sessions[dateOnly] = [];
 		}
+
+		sessions[dateOnly].push(match);
 	});
 
-	return sessions;
+	return Object.values(sessions);
 };


### PR DESCRIPTION
Changed the logic of match grouping: now matches are grouped strictly by a unique date (day, month, year), and not by the time interval between them. This allows all matches played on the same day to be correctly displayed in one group and simplifies the analysis of statistics by day.
Fixes an issue where matches with the same date could fall into different sessions.

Fixes #10 