### PR TITLE
Support best of 3 match pages

### DIFF
--- a/apps/web/src/entities/match/lib/date.ts
+++ b/apps/web/src/entities/match/lib/date.ts
@@ -20,3 +20,9 @@ export const formatMatchDate = (date: Date) => {
 
 	return `${day} of ${monthYear}`;
 };
+
+export const formatDateDifference = (startedAt: Date, finishedAt: Date) => {
+	const diff = datefns.intervalToDuration({start: startedAt, end: finishedAt})
+
+	return `${diff.hours ? `${diff.hours} hour${diff.hours > 1 ? 's' : ''}, ` : ""}${diff.minutes ?? 0} minute${diff.minutes && diff.minutes != 1 ? 's' : ''}`;
+};

--- a/apps/web/src/entities/match/ui/index.ts
+++ b/apps/web/src/entities/match/ui/index.ts
@@ -1,1 +1,2 @@
 export {MatchStats} from "./match-stats";
+export {MapSelect} from "./map-select";

--- a/apps/web/src/entities/match/ui/index.ts
+++ b/apps/web/src/entities/match/ui/index.ts
@@ -1,2 +1,3 @@
 export {MatchStats} from "./match-stats";
 export {MapSelect} from "./map-select";
+export {MapCard} from "./map-card";

--- a/apps/web/src/entities/match/ui/map-card.tsx
+++ b/apps/web/src/entities/match/ui/map-card.tsx
@@ -1,0 +1,127 @@
+import {Avatar} from "@shared/ui";
+import {cx} from "class-variance-authority";
+import {TeamScore} from "types/score";
+
+interface MapCardProps {
+	team1Score?: TeamScore;
+	team2Score?: TeamScore;
+	mapName: string;
+	team1Avatar: string;
+	team1Name: string;
+	team2Avatar: string;
+	team2Name: string;
+	isOvertime: boolean;
+}
+
+export const MapCard: React.FC<MapCardProps> = ({
+	team1Score,
+	team2Score,
+	mapName,
+	team1Avatar,
+	team1Name,
+	team2Avatar,
+	team2Name,
+	isOvertime,
+}) => {
+	const isMapPlayed = team1Score || team2Score;
+
+	return (
+		<div className="flex flex-col rounded-4 overflow-hidden">
+			<div className="flex items-center justify-center relative">
+				<img
+					src={`https://hltv.org/img/static/maps/${mapName.slice(3)}.png`}
+					alt="Map"
+					className="w-full h-auto"
+				/>
+
+				<span className="absolute left-1/2 top-1/2 -translate-y-1/2 -translate-x-1/2 text-[#fff] font-bold text-14">
+					{
+						{
+							de_mirage: "Mirage",
+							de_anubis: "Anubis",
+							de_dust2: "Dust 2",
+							de_vertigo: "Vertigo",
+							de_inferno: "Inferno",
+							de_nuke: "Nuke",
+							de_ancient: "Ancient",
+							de_train: "Train",
+							de_cbble: "Cobblestone",
+							de_overpass: "Overpass",
+						}[mapName]
+					}
+				</span>
+			</div>
+
+			<div className="flex bg-[#2D3844] justify-between items-center p-18">
+				<div className="w-1/3 flex items-start space-x-12 overflow-hidden">
+					<Avatar
+						src={team1Avatar}
+						alt="First team's avatar"
+						className="min-w-32 max-w-32 h-auto rounded-full"
+					/>
+
+					<div className="flex flex-col items-start overflow-hidden">
+						<span className="w-full overflow-hidden text-ellipsis text-[#929a9e] font-bold text-12">
+							{team1Name}
+						</span>
+
+						<span
+							className={cx(
+								"font-bold text-[#b9bdbf] !text-14",
+								isMapPlayed && {
+									"!text-[#09c100]":
+										(team2Score?.score ?? 0) >
+										(team1Score?.score ?? 0),
+									"!text-[#fc1d1d]":
+										(team1Score?.score ?? 0) >
+										(team2Score?.score ?? 0),
+								},
+							)}
+						>
+							{isMapPlayed ? team1Score?.score : "-"}
+						</span>
+					</div>
+				</div>
+
+				<div className="w-1/3 mt-auto overflow-hidden flex justify-center">
+					{isMapPlayed && (
+						<span className="text-[#929a9e] font-normal text-12">
+							{`(${team1Score?.firstHalfScore}:${team2Score?.firstHalfScore}; ${team1Score?.secondHalfScore}:${team2Score?.secondHalfScore})${
+								isOvertime
+									? ` (${team1Score?.overtimeScore}:${team2Score?.overtimeScore})`
+									: ""
+							}`}
+						</span>
+					)}
+				</div>
+
+				<div className="w-1/3 flex items-start space-x-12 overflow-hidden">
+					<div className="flex flex-1 flex-col items-end overflow-hidden">
+						<span className="w-full overflow-hidden text-ellipsis text-[#929a9e] font-bold text-12 text-end">
+							{team2Name}
+						</span>
+
+						<span
+							className={cx("font-bold text-[#b9bdbf] !text-14", {
+								"!text-[#09c100]":
+									(team1Score?.score ?? 0) >
+									(team2Score?.score ?? 0),
+								"!text-[#fc1d1d]":
+									(team2Score?.score ?? 0) >
+									(team1Score?.score ?? 0),
+							})}
+						>
+							{isMapPlayed ? team2Score?.score : "-"}
+						</span>
+					</div>
+
+					<Avatar
+						src={team2Avatar}
+						alt="Second team's avatar"
+						className="min-w-32 max-w-32 h-auto rounded-full"
+					/>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/apps/web/src/entities/match/ui/map-select.tsx
+++ b/apps/web/src/entities/match/ui/map-select.tsx
@@ -10,8 +10,9 @@ export const MapSelect: React.FC<MapSelectProps> = ({
 	setActiveMap,
 }) => (
 	<div className="flex flex-row bg-[#232d38] text-14 xs:text-12 text-[#929a9e] px-16 items-center space-x-18 py-12">
-		{maps.map((m) => (
+		{maps.map((m, i) => (
 			<button
+				key={i}
 				className={activeMap == m.value ? "font-bold" : ""}
 				onClick={() => setActiveMap(`${m.value}`)}
 			>

--- a/apps/web/src/entities/match/ui/map-select.tsx
+++ b/apps/web/src/entities/match/ui/map-select.tsx
@@ -1,9 +1,7 @@
-import {Dispatch, SetStateAction} from "react";
-
 interface MapSelectProps {
 	maps: {name: string; value: number}[];
 	activeMap: number;
-	setActiveMap: Dispatch<SetStateAction<number>>;
+	setActiveMap: (map: string) => void
 }
 
 export const MapSelect: React.FC<MapSelectProps> = ({
@@ -15,7 +13,7 @@ export const MapSelect: React.FC<MapSelectProps> = ({
 		{maps.map((m) => (
 			<button
 				className={activeMap == m.value ? "font-bold" : ""}
-				onClick={() => setActiveMap(m.value)}
+				onClick={() => setActiveMap(`${m.value}`)}
 			>
 				{
 					{

--- a/apps/web/src/entities/match/ui/map-select.tsx
+++ b/apps/web/src/entities/match/ui/map-select.tsx
@@ -1,0 +1,37 @@
+import {Dispatch, SetStateAction} from "react";
+
+interface MapSelectProps {
+	maps: {name: string; value: number}[];
+	activeMap: number;
+	setActiveMap: Dispatch<SetStateAction<number>>;
+}
+
+export const MapSelect: React.FC<MapSelectProps> = ({
+	maps,
+	activeMap,
+	setActiveMap,
+}) => (
+	<div className="flex flex-row bg-[#232d38] text-14 xs:text-12 text-[#929a9e] px-16 items-center space-x-18 py-12">
+		{maps.map((m) => (
+			<button
+				className={activeMap == m.value ? "font-bold" : ""}
+				onClick={() => setActiveMap(m.value)}
+			>
+				{
+					{
+						de_mirage: "Mirage",
+						de_anubis: "Anubis",
+						de_dust2: "Dust 2",
+						de_vertigo: "Vertigo",
+						de_inferno: "Inferno",
+						de_nuke: "Nuke",
+						de_ancient: "Ancient",
+						de_train: "Train",
+						de_cbble: "Cobblestone",
+						de_overpass: "Overpass",
+					}[m.name]
+				}
+			</button>
+		))}
+	</div>
+);

--- a/apps/web/src/pages/match.tsx
+++ b/apps/web/src/pages/match.tsx
@@ -19,7 +19,6 @@ import {formatDateDifference} from "@entities/match/lib/date";
 /*
 	TODO
 	- [] bonus: ability to view stats for 'all maps'
-	- [] bonus: veto option 7. should be "<MAP> left over"
 	- [] added bonus - ability to select "side" to view stats based off if they're T or CT
 	- [] added bonus - have half scores in map card be coloured based off side
 	- [] added bonus - cleanup "Server" section
@@ -223,21 +222,9 @@ export const MatchPage: React.FC = () => {
 													process.entity_type ===
 													"map",
 											)
-											?.entities.map((entity, idx) => (
-												<li
-													key={idx}
-													className="ml-18 break-words"
-												>
-													{`Team ${
-														{
-															faction1:
-																match.team1
-																	.name,
-															faction2:
-																match.team2
-																	.name,
-														}[entity.selected_by]
-													} ${{pick: "picked", drop: "removed"}[entity.status]} ${
+											?.entities.map(
+												(entity, idx, entities) => {
+													const mapName = `${
 														{
 															de_mirage: "Mirage",
 															de_anubis: "Anubis",
@@ -253,10 +240,36 @@ export const MatchPage: React.FC = () => {
 															de_overpass:
 																"Overpass",
 														}[entity.guid]
-													}
+													}`;
+
+													return (
+														<li
+															key={idx}
+															className="ml-18 break-words"
+														>
+															{idx ===
+															entities.length - 1
+																? `${mapName} was left over`
+																: `Team ${
+																		{
+																			faction1:
+																				match
+																					.team1
+																					.name,
+																			faction2:
+																				match
+																					.team2
+																					.name,
+																		}[
+																			entity
+																				.selected_by
+																		]
+																	} ${{pick: "picked", drop: "removed"}[entity.status]} ${mapName}
                                                 `}
-												</li>
-											))}
+														</li>
+													);
+												},
+											)}
 									</ul>
 								)}
 

--- a/apps/web/src/pages/match.tsx
+++ b/apps/web/src/pages/match.tsx
@@ -8,10 +8,12 @@ import {
 	useMatch,
 	MatchStats,
 	MapSelect,
+	MapCard,
 } from "@entities/match";
 import {calculateAverageStats} from "@entities/profile";
 import {Loader} from "@shared/ui/loader";
 import {Avatar, Center, Container, Fullscreen} from "@shared/ui";
+import { Score } from "types/score";
 
 /*
 	TODO
@@ -25,13 +27,16 @@ import {Avatar, Center, Container, Fullscreen} from "@shared/ui";
 	- [] added bonus - demo download links below server section
 */
 
+
+
 export const MatchPage: React.FC = () => {
 	const {matchId} = useParams() as {matchId: string};
 	const [searchParams, setSearchParams] = useSearchParams();
 
 	const {match, isLoading, isError} = useMatch(matchId);
 
-	const activeMap = +searchParams.get('map')! > 0 ? +searchParams.get('map')! : 0
+	const activeMap =
+		+searchParams.get("map")! > 0 ? +searchParams.get("map")! : 0;
 
 	if (isLoading)
 		return (
@@ -53,7 +58,7 @@ export const MatchPage: React.FC = () => {
 
 	if (!match) return;
 
-	const score = {
+	const score: Score = {
 		team1: match?.stats.map((s) =>
 			s.score.find((s) => s.teamId === match.team1.faction_id),
 		),
@@ -257,143 +262,19 @@ export const MatchPage: React.FC = () => {
 									</ul>
 								)}
 
-								{match.maps?.map((m, i) => {
-									const team1Score = score.team1[i];
-									const team2Score = score.team2[i];
-									const isMapPlayed =
-										team1Score || team2Score;
-
-									return (
-										<div className="flex flex-col rounded-4 overflow-hidden">
-											<div className="flex items-center justify-center relative">
-												<img
-													src={`https://hltv.org/img/static/maps/${m.name?.slice(3)}.png`}
-													alt="Map"
-													className="w-full h-auto"
-												/>
-
-												{match && (
-													<span className="absolute left-1/2 top-1/2 -translate-y-1/2 -translate-x-1/2 text-[#fff] font-bold text-14">
-														{
-															{
-																de_mirage:
-																	"Mirage",
-																de_anubis:
-																	"Anubis",
-																de_dust2:
-																	"Dust 2",
-																de_vertigo:
-																	"Vertigo",
-																de_inferno:
-																	"Inferno",
-																de_nuke: "Nuke",
-																de_ancient:
-																	"Ancient",
-																de_train:
-																	"Train",
-																de_cbble:
-																	"Cobblestone",
-																de_overpass:
-																	"Overpass",
-															}[m.name!]
-														}
-													</span>
-												)}
-											</div>
-
-											<div className="flex bg-[#2D3844] justify-between items-center p-18">
-												<div className="w-1/3 flex items-start space-x-12 overflow-hidden">
-													<Avatar
-														src={
-															match?.team1.avatar
-														}
-														alt="First team's avatar"
-														className="min-w-32 max-w-32 h-auto rounded-full"
-													/>
-
-													<div className="flex flex-col items-start overflow-hidden">
-														<span className="w-full overflow-hidden text-ellipsis text-[#929a9e] font-bold text-12">
-															{match?.team1.name}
-														</span>
-
-														<span
-															className={cx(
-																"font-bold text-[#b9bdbf] !text-14",
-																isMapPlayed && {
-																	"!text-[#09c100]":
-																		(team2Score?.score ??
-																			0) >
-																		(team1Score?.score ??
-																			0),
-																	"!text-[#fc1d1d]":
-																		(team1Score?.score ??
-																			0) >
-																		(team2Score?.score ??
-																			0),
-																},
-															)}
-														>
-															{isMapPlayed
-																? team1Score?.score
-																: "-"}
-														</span>
-													</div>
-												</div>
-
-												<div className="w-1/3 mt-auto overflow-hidden flex justify-center">
-													{isMapPlayed && (
-														<span className="text-[#929a9e] font-normal text-12">
-															{`(${team1Score?.firstHalfScore}:${team2Score?.firstHalfScore}; ${team1Score?.secondHalfScore}:${team2Score?.secondHalfScore})${
-																match?.stats[i]
-																	.isOvertime
-																	? ` (${team1Score?.overtimeScore}:${team2Score?.overtimeScore})`
-																	: ""
-															}`}
-														</span>
-													)}
-												</div>
-
-												<div className="w-1/3 flex items-start space-x-12 overflow-hidden">
-													<div className="flex flex-1 flex-col items-end overflow-hidden">
-														<span className="w-full overflow-hidden text-ellipsis text-[#929a9e] font-bold text-12 text-end">
-															{match?.team2.name}
-														</span>
-
-														<span
-															className={cx(
-																"font-bold text-[#b9bdbf] !text-14",
-																{
-																	"!text-[#09c100]":
-																		(team1Score?.score ??
-																			0) >
-																		(team2Score?.score ??
-																			0),
-																	"!text-[#fc1d1d]":
-																		(team2Score?.score ??
-																			0) >
-																		(team1Score?.score ??
-																			0),
-																},
-															)}
-														>
-															{isMapPlayed
-																? team2Score?.score
-																: "-"}
-														</span>
-													</div>
-
-													<Avatar
-														src={
-															match?.team2.avatar
-														}
-														alt="Second team's avatar"
-														className="min-w-32 max-w-32 h-auto rounded-full"
-													/>
-												</div>
-											</div>
-										</div>
-									);
-								})}
+								{match.maps?.map((m, i) => (
+									<MapCard
+										key={i}
+										team1Score={score.team1[i]}
+										team2Score={score.team2[i]}
+										mapName={m.name ?? ""}
+										team1Avatar={match.team1.avatar}
+										team1Name={match.team1.name}
+										team2Avatar={match.team2.avatar}
+										team2Name={match.team2.name}
+										isOvertime={match.stats[i] && match.stats[i].isOvertime}
+									/>
+								))}
 							</div>
 						</div>
 
@@ -464,7 +345,9 @@ export const MatchPage: React.FC = () => {
 											.slice(0, stats.length) ?? []
 									}
 									activeMap={activeMap}
-									setActiveMap={(map: string) => setSearchParams({'map': map})}
+									setActiveMap={(map: string) =>
+										setSearchParams({map: map})
+									}
 								/>
 							)}
 

--- a/apps/web/src/pages/match.tsx
+++ b/apps/web/src/pages/match.tsx
@@ -16,16 +16,6 @@ import {Avatar, Center, Container, Fullscreen} from "@shared/ui";
 import {Score} from "types/score";
 import {formatDateDifference} from "@entities/match/lib/date";
 
-/*
-	TODO
-	- [] bonus: ability to view stats for 'all maps'
-	- [] added bonus - ability to select "side" to view stats based off if they're T or CT
-	- [] added bonus - have half scores in map card be coloured based off side
-	- [] added bonus - cleanup "Server" section
-	- [] added bonus - pick banner on map card
-	- [] added bonus - demo download links below server section
-*/
-
 export const MatchPage: React.FC = () => {
 	const {matchId} = useParams() as {matchId: string};
 	const [searchParams, setSearchParams] = useSearchParams();
@@ -293,51 +283,78 @@ export const MatchPage: React.FC = () => {
 						</div>
 
 						<div className="w-1/2 flex flex-col space-y-16">
+							{match?.veto?.find(
+								(process) => process.entity_type === "location",
+							) && (
+								<>
+									<h5 className="text-[#929a9e] text-20 font-bold">
+										Server
+									</h5>
+
+									<div className="w-full flex flex-col space-y-12 text-[#929a9e]">
+										<ul className="w-full flex flex-col bg-[#2D3844] p-18 rounded-4 space-y-6 list-decimal text-14">
+											{match.veto
+												.find(
+													(process) =>
+														process.entity_type ===
+														"location",
+												)
+												?.entities.map(
+													(entity, idx) => (
+														<li
+															key={idx}
+															className="ml-18 break-words"
+														>
+															{`Team ${
+																{
+																	faction1:
+																		match
+																			.team1
+																			.name,
+																	faction2:
+																		match
+																			.team2
+																			.name,
+																}[
+																	entity
+																		.selected_by
+																]
+															} ${{pick: "picked", drop: "removed"}[entity.status]} ${
+																entity.guid
+															}
+                                                `}
+														</li>
+													),
+												)}
+										</ul>
+
+										<div className="flex space-x-14 items-center rounded-4 bg-[#2D3844] overflow-hidden p-18">
+											<img
+												src={match?.server.image.lg}
+												alt="Server location country"
+												className="w-72 h-auto rounded-2"
+											/>
+
+											<span>{match?.server.name}</span>
+										</div>
+									</div>
+								</>
+							)}
+
 							<h5 className="text-[#929a9e] text-20 font-bold">
-								Server
+								Rewatch
 							</h5>
 
-							<div className="w-full flex flex-col space-y-12 text-[#929a9e]">
-								{match?.veto && (
-									<ul className="w-full flex flex-col bg-[#2D3844] p-18 rounded-4 space-y-6 list-decimal text-14">
-										{match.veto
-											.find(
-												(process) =>
-													process.entity_type ===
-													"location",
-											)
-											?.entities.map((entity, idx) => (
-												<li
-													key={idx}
-													className="ml-18 break-words"
-												>
-													{`Team ${
-														{
-															faction1:
-																match.team1
-																	.name,
-															faction2:
-																match.team2
-																	.name,
-														}[entity.selected_by]
-													} ${{pick: "picked", drop: "removed"}[entity.status]} ${
-														entity.guid
-													}
-                                                `}
-												</li>
-											))}
-									</ul>
-								)}
-
-								<div className="flex space-x-14 items-center rounded-4 bg-[#2D3844] overflow-hidden p-18">
-									<img
-										src={match?.server.image.lg}
-										alt="Server location country"
-										className="w-72 h-auto rounded-2"
-									/>
-
-									<span>{match?.server.name}</span>
-								</div>
+							<div className="w-full flex flex-col text-[#929a9e] bg-[#2D3844] rounded-4 text-14">
+								<a
+									href={`https://www.faceit.com/en/cs2/room/${match?.id}`}
+									target="_blank"
+									className="break-words hover:bg-[#45515f] w-full h-full"
+								>
+									<div className="p-18">
+										Go to Matchroom
+									</div>
+								</a>
 							</div>
 						</div>
 					</div>

--- a/apps/web/src/pages/match.tsx
+++ b/apps/web/src/pages/match.tsx
@@ -13,12 +13,12 @@ import {
 import {calculateAverageStats} from "@entities/profile";
 import {Loader} from "@shared/ui/loader";
 import {Avatar, Center, Container, Fullscreen} from "@shared/ui";
-import { Score } from "types/score";
+import {Score} from "types/score";
+import {formatDateDifference} from "@entities/match/lib/date";
 
 /*
 	TODO
 	- [] bonus: ability to view stats for 'all maps'
-	- [] bonus: time should be for overall series, not first map
 	- [] bonus: veto option 7. should be "<MAP> left over"
 	- [] added bonus - ability to select "side" to view stats based off if they're T or CT
 	- [] added bonus - have half scores in map card be coloured based off side
@@ -26,8 +26,6 @@ import { Score } from "types/score";
 	- [] added bonus - pick banner on map card
 	- [] added bonus - demo download links below server section
 */
-
-
 
 export const MatchPage: React.FC = () => {
 	const {matchId} = useParams() as {matchId: string};
@@ -164,9 +162,9 @@ export const MatchPage: React.FC = () => {
 
 								<span className="text-[#929a9e] text-12">
 									{match &&
-										datefns.formatDistanceStrict(
-											match.finishedAt,
+										formatDateDifference(
 											match.startedAt,
+											match.finishedAt,
 										)}
 								</span>
 							</div>
@@ -272,7 +270,10 @@ export const MatchPage: React.FC = () => {
 										team1Name={match.team1.name}
 										team2Avatar={match.team2.avatar}
 										team2Name={match.team2.name}
-										isOvertime={match.stats[i] && match.stats[i].isOvertime}
+										isOvertime={
+											match.stats[i] &&
+											match.stats[i].isOvertime
+										}
 									/>
 								))}
 							</div>

--- a/apps/web/src/pages/match.tsx
+++ b/apps/web/src/pages/match.tsx
@@ -1,4 +1,4 @@
-import {Link, useParams} from "wouter";
+import {Link, useParams, useSearchParams} from "wouter";
 import * as datefns from "date-fns";
 import {cx} from "class-variance-authority";
 import {twMerge} from "tailwind-merge";
@@ -12,13 +12,9 @@ import {
 import {calculateAverageStats} from "@entities/profile";
 import {Loader} from "@shared/ui/loader";
 import {Avatar, Center, Container, Fullscreen} from "@shared/ui";
-import {useState} from "react";
 
 /*
 	TODO
-	- [x] scores in header should be bo3 score, not rounds (i.e. 2-1, not 13-5)
-	- [x] all maps cards should be visible below veto
-	- [x] stats section should have option to click on map to look at specific leaderboards (e.g. All Maps, Nuke, Inferno, Mirage)
 	- [] bonus: ability to view stats for 'all maps'
 	- [] bonus: time should be for overall series, not first map
 	- [] bonus: veto option 7. should be "<MAP> left over"
@@ -31,9 +27,11 @@ import {useState} from "react";
 
 export const MatchPage: React.FC = () => {
 	const {matchId} = useParams() as {matchId: string};
+	const [searchParams, setSearchParams] = useSearchParams();
 
 	const {match, isLoading, isError} = useMatch(matchId);
-	const [activeMap, setActiveMap] = useState(0); //TODO - move this to url so that map stats become shareable
+
+	const activeMap = +searchParams.get('map')! > 0 ? +searchParams.get('map')! : 0
 
 	if (isLoading)
 		return (
@@ -466,7 +464,7 @@ export const MatchPage: React.FC = () => {
 											.slice(0, stats.length) ?? []
 									}
 									activeMap={activeMap}
-									setActiveMap={setActiveMap}
+									setActiveMap={(map: string) => setSearchParams({'map': map})}
 								/>
 							)}
 

--- a/apps/web/src/shared/api.ts
+++ b/apps/web/src/shared/api.ts
@@ -305,7 +305,7 @@ export const getMatch = async (matchId: GetMatchDto["req"]) => {
 
 	return {
 		id: match.match_id,
-		startedAt: new Date(match.started_at * 1000),
+		startedAt: match.scheduled_at ? new Date(match.scheduled_at * 1000) : new Date(match.started_at * 1000),
 		finishedAt: new Date(match.finished_at * 1000),
 		bo: match.best_of,
 		team1: match.teams.faction1,

--- a/apps/web/src/shared/api.ts
+++ b/apps/web/src/shared/api.ts
@@ -315,6 +315,10 @@ export const getMatch = async (matchId: GetMatchDto["req"]) => {
 			team1: match.results.winner === "faction1",
 			team2: match.results.winner === "faction2",
 		},
+		score: {
+			team1: match.results.score.faction1,
+			team2: match.results.score.faction2,
+		},
 		demo: match.demo_url[0],
 		server: {
 			name: server,
@@ -327,6 +331,20 @@ export const getMatch = async (matchId: GetMatchDto["req"]) => {
 				)?.image_lg,
 			},
 		},
+		maps: match.voting.map?.pick.map((m) => {
+			return {
+				name: m,
+				image: {
+					sm: match.voting.map?.entities.find(
+						(entity) => entity.guid === m,
+					)?.image_sm,
+					lg: match.voting.map?.entities.find(
+						(entity) => entity.guid === m,
+					)?.image_lg,
+				},
+			}
+		}),
+		// TODO - remove below
 		map: {
 			name: map,
 			image: {
@@ -437,33 +455,35 @@ export const getMatchStats = async (matchId: GetMatchStatsDto["req"]) => {
 		method: "GET",
 	});
 
-	const team1 = rounds[0].teams[0];
-	const team2 = rounds[0].teams[1];
+	return rounds.map((r) => {
+		const team1 = r.teams[0];
+		const team2 = r.teams[1];
 
-	return {
-		score: [
-			{
-				teamId: team1.team_id,
-				firstHalfScore: team1.team_stats["First Half Score"],
-				secondHalfScore: team1.team_stats["Second Half Score"],
-				score: team1.team_stats["Final Score"],
-				overtimeScore: team1.team_stats["Overtime score"],
-			},
-			{
-				teamId: team2.team_id,
-				firstHalfScore: team2.team_stats["First Half Score"],
-				secondHalfScore: team2.team_stats["Second Half Score"],
-				score: team2.team_stats["Final Score"],
-				overtimeScore: team2.team_stats["Overtime score"],
-			},
-		],
-		isOvertime:
-			+team1.team_stats["Overtime score"] ||
-			+team2.team_stats["Overtime score"],
-		team1: team1.players,
-		team2: team2.players,
-		rounds: +rounds[0].round_stats.Rounds,
-	};
+		return {
+			score: [
+				{
+					teamId: team1.team_id,
+					firstHalfScore: team1.team_stats["First Half Score"],
+					secondHalfScore: team1.team_stats["Second Half Score"],
+					score: team1.team_stats["Final Score"],
+					overtimeScore: team1.team_stats["Overtime score"],
+				},
+				{
+					teamId: team2.team_id,
+					firstHalfScore: team2.team_stats["First Half Score"],
+					secondHalfScore: team2.team_stats["Second Half Score"],
+					score: team2.team_stats["Final Score"],
+					overtimeScore: team2.team_stats["Overtime score"],
+				},
+			],
+			isOvertime:
+				+team1.team_stats["Overtime score"] > 0 ||
+				+team2.team_stats["Overtime score"] > 0,
+			team1: team1.players,
+			team2: team2.players,
+			rounds: +r.round_stats.Rounds,
+		};
+	});
 };
 
 type GetPlayerDetailsDto = Dto<

--- a/apps/web/types/score.ts
+++ b/apps/web/types/score.ts
@@ -1,0 +1,12 @@
+export type Score = {
+	team1: (TeamScore | undefined)[];
+	team2: (TeamScore | undefined)[];
+};
+
+export type TeamScore = {
+	teamId: string;
+	firstHalfScore: string;
+	secondHalfScore: string;
+	score: string;
+	overtimeScore: string;
+};


### PR DESCRIPTION
- If bo1, render individual map score in header (e.g. 13-4). If bo3, render map scores in header (e.g. 2-1)
- Updated time duration string in header
- Refactored MapCard, and render multiple maps for bo3's
- Support for Overpass as a map string
- Added a link to the original faceit matchroom
- Ability to switch between maps in Match Stats section to show stats for specific maps. I did want to add an "All Maps" section as well, but don't understand the stats calculations enough to build on this idea.

BO1 Matchpage example:
<img width="1920" height="1604" alt="image" src="https://github.com/user-attachments/assets/3d5b614a-2267-453c-a224-7c37012b35d1" />

BO3 Matchpage example:
<img width="1296" height="1723" alt="image" src="https://github.com/user-attachments/assets/af6a0152-88fb-4a8e-a15e-9a199ce6a678" />
